### PR TITLE
Fix Django2.0 Compatibility

### DIFF
--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -19,7 +19,8 @@ class Device(models.Model):
         verbose_name=_("Is active"), default=True,
         help_text=_("Inactive devices will not be sent notifications")
     )
-    user = models.ForeignKey(SETTINGS["USER_MODEL"], blank=True, null=True)
+    user = models.ForeignKey(SETTINGS["USER_MODEL"], blank=True, null=True,
+                             on_delete=models.CASCADE)
     date_created = models.DateTimeField(
         verbose_name=_("Creation date"), auto_now_add=True, null=True
     )


### PR DESCRIPTION
Django 2.0 does not set a default value for on_delete method in ForeingKeys. Now it must be set manually.

This fixes the problem and makes the module compatible with Django 2.0