### PR TITLE
Fix re-registering the registration ID for same user

### DIFF
--- a/fcm_django/api/rest_framework.py
+++ b/fcm_django/api/rest_framework.py
@@ -63,7 +63,7 @@ class UniqueRegistrationSerializerMixin(Serializer):
                 devices = Device.objects.filter(
                     registration_id=attrs["registration_id"])
                 devices.filter(~Q(user=user)).update(active=False)
-                devices = devices.filter(user=user)
+                devices = devices.filter(user=user, active=True)
             else:
                 devices = Device.objects.filter(
                     registration_id=attrs["registration_id"])


### PR DESCRIPTION
Hi!

Would you like to consider pulling this into the main repo:

I've found out that it's currently impossible, with the rest_framework API, to re-register the registration ID with one user if the same registration ID has been since registered with some other user. In other words, it *is* possible to "switch" user of the registration ID by calling the API with POST ("create") method, but it is not possible to switch back. The following pseudo-ish flow with curl attempts to demonstrate this even more:

1. Register application's registration ID for first user (this works with current fcm-django master branch):
`$ curl -H "Content-Type: application/json" -H "Authorization: Token user1-creds"  127.0.0.1:8000/fcm/devices/ -X POST -d '{"type": "android", "registration_id": "my-test-registration-id"}'`

2. User is changed in-app, so register the same registration id for this user (this also works):
`$ curl -H "Content-Type: application/json" -H "Authorization: Token OTHER-user2-creds"  127.0.0.1:8000/fcm/devices/ -X POST -d '{"type": "android", "registration_id": "my-test-registration-id"}'`

3. User is changed back to the first one, so again register application's registration ID for first user (this *doesn't* currently work. and returns `"registration_id": ["This field must be unique."]` error):
`$ curl -H "Content-Type: application/json" -H "Authorization: Token user1-creds"  127.0.0.1:8000/fcm/devices/ -X POST -d '{"type": "android", "registration_id": "my-test-registration-id"}'`

`FCM_DJANGO_SETTINGS` in this case are as follows:

```
FCM_DJANGO_SETTINGS = {
    'FCM_SERVER_KEY': "...",
    'ONE_DEVICE_PER_USER': True,
    'DELETE_INACTIVE_DEVICES': True,
}
```

With the change in this pull request the API would return `"registration_id": ["This field must be unique."]` *only* if the calling user already has this registration ID as the active one.

