### PR TITLE
Added Django 1.7 support, created extension to uuidfield

### DIFF
--- a/fcm_django/migrations/0001_initial.py
+++ b/fcm_django/migrations/0001_initial.py
@@ -6,6 +6,10 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 
+try:
+    UUIDField = models.UUIDField
+except AttributeError:
+    from uuidfield import UUIDField
 
 class Migration(migrations.Migration):
 
@@ -21,7 +25,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(blank=True, max_length=255, null=True, verbose_name='Name')),
                 ('active', models.BooleanField(default=True, help_text='Inactive devices will not be sent notifications', verbose_name='Is active')),
                 ('date_created', models.DateTimeField(auto_now_add=True, null=True, verbose_name='Creation date')),
-                ('device_id', models.UUIDField(blank=True, db_index=True, help_text='GUID()', null=True, verbose_name='Device ID')),
+                ('device_id', UUIDField(blank=True, db_index=True, help_text='GUID()', null=True, verbose_name='Device ID')),
                 ('registration_id', models.TextField(verbose_name='Registration token')),
                 ('type', models.CharField(choices=[('ios', 'ios'), ('android', 'android')], max_length=10)),
                 ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyfcm==1.4.3
+django-uuidfield==0.5.0


### PR DESCRIPTION
In fcm-django firstly used UUID Field for device_id, then it reformatted to CharField. But in migrations there are initial migration for device_id = models.UUIDField. We should either regenerate migrations or use my extension for migrate an app in Django<1.8.  