### PR TITLE
id field for FCMDeviceSerializer made read_only

### DIFF
--- a/fcm_django/api/rest_framework.py
+++ b/fcm_django/api/rest_framework.py
@@ -90,7 +90,7 @@ class FCMDeviceSerializer(ModelSerializer, UniqueRegistrationSerializerMixin):
     class Meta(DeviceSerializerMixin.Meta):
         model = FCMDevice
 
-        extra_kwargs = {"id": {"read_only": False, "required": False}}
+        extra_kwargs = {"id": {"read_only": True, "required": False}}
         extra_kwargs.update(DeviceSerializerMixin.Meta.extra_kwargs)
 
 


### PR DESCRIPTION
This change is made for this issue [https://github.com/xtrinch/fcm-django/issues/61](https://github.com/xtrinch/fcm-django/issues/61)
Right now, The id field of a FCMDevice can be given with the input from FCMDeviceViewSet where a frontend developer might have no idea which ID is available and which is not, 
Also, upon request with a `id` which is already taken it does not respond with an error message but responds with a server error. `(Error 500)`

For this, I would like to propose that the id field of FCMDevice should be read_only.