### PR TITLE
fix migration error for django < 2

### DIFF
--- a/fcm_django/migrations/0005_auto_20181128_1642.py
+++ b/fcm_django/migrations/0005_auto_20181128_1642.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('fcm_django', '0003_auto_20170313_1314'),
+        ('fcm_django', '0004_auto_20170808_1145'),
     ]
 
     operations = [


### PR DESCRIPTION
v0.3.0 migration error fixed https://github.com/xtrinch/fcm-django/issues/102