### PR TITLE
Remove Django 3.0 Incompatibility

### DIFF
--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from .settings import FCM_DJANGO_SETTINGS as SETTINGS
 
 
-@python_2_unicode_compatible
 class Device(models.Model):
     name = models.CharField(
         max_length=255,


### PR DESCRIPTION
On Django 3.0 python_2_unicode_compatible doesnt exists.