### PR TITLE
Can't properly override FCMDevice

### DIFF
--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -242,7 +242,7 @@ class AbstractFCMDevice(Device):
         return result
 
     def _deactivate_device_on_error_result(self, result):
-        device = FCMDevice.objects.filter(registration_id=self.registration_id)
+        device = self.objects.filter(registration_id=self.registration_id)
         if 'error' in result['results'][0]:
             error_list = ['MissingRegistration', 'MismatchSenderId', 'InvalidRegistration', 'NotRegistered']
             if result['results'][0]['error'] in error_list:


### PR DESCRIPTION
Hello FCM-Django community, thanks for the hard work!

As I needed to add a custom field to the `FCMDevice` model (I need a **lang** field) I realised that I couldn't easily replace the model and inherit from `AbstractFCMDevice` because it uses `FCMDevice.objects`.

Here is a quick PR that will remove this dependency and uses `self.objects` instead.

Please do let me know if I'm missing something.

Cheers,