### PR TITLE
Fix device_id's max_length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ fcm_django.egg-info
 # IDE
 .idea
 *.iml
+.vscode
 
 # virtualenv
 .env

--- a/fcm_django/migrations/0006_auto_20210802_1140.py
+++ b/fcm_django/migrations/0006_auto_20210802_1140.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 db_index=True,
                 help_text="Unique device identifier",
-                max_length=3072,
+                max_length=255,
                 null=True,
                 verbose_name="Device ID",
             ),

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -262,7 +262,7 @@ class AbstractFCMDevice(Device):
         null=True,
         db_index=True,
         help_text=_("Unique device identifier"),
-        max_length=3072,
+        max_length=255,
     )
     registration_id = models.TextField(verbose_name=_("Registration token"))
     type = models.CharField(choices=DEVICE_TYPES, max_length=10)


### PR DESCRIPTION
The safe number for all DB types supported by Django is 255.
and even if we want to support only a handful of them, 3072 bytes is equal to max_length of 768.