### PR TITLE
Use BigAutoField as the default ID

### DIFF
--- a/fcm_django/apps.py
+++ b/fcm_django/apps.py
@@ -6,3 +6,4 @@ from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 class FcmDjangoConfig(AppConfig):
     name = "fcm_django"
     verbose_name = SETTINGS["APP_VERBOSE_NAME"]
+    default_auto_field = "django.db.models.BigAutoField"

--- a/fcm_django/migrations/0007_auto_20211001_1440.py
+++ b/fcm_django/migrations/0007_auto_20211001_1440.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fcm_django", "0006_auto_20210802_1140"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="fcmdevice",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True,
+                primary_key=True,
+                serialize=False,
+                verbose_name="ID",
+            ),
+        ),
+    ]

--- a/fcm_django/migrations/0007_auto_20211001_1440.py
+++ b/fcm_django/migrations/0007_auto_20211001_1440.py
@@ -11,11 +11,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="fcmdevice",
             name="id",
-            field=models.BigAutoField(
-                auto_created=True,
-                primary_key=True,
-                serialize=False,
-                verbose_name="ID",
-            ),
+            field=models.BigAutoField(primary_key=True, serialize=False),
         ),
     ]


### PR DESCRIPTION
Specify BigAutoField in this app so that users don't have some auto generating migrations file that they automatically migrate.

Fixes #182 