### PR TITLE
Add ordering to FCMDeviceViewSet

### DIFF
--- a/fcm_django/api/rest_framework.py
+++ b/fcm_django/api/rest_framework.py
@@ -153,7 +153,7 @@ class AuthorizedMixin:
 
 # ViewSets
 class FCMDeviceViewSet(DeviceViewSetMixin, ModelViewSet):
-    queryset = FCMDevice.objects.all()
+    queryset = FCMDevice.objects.order_by('-id')
     serializer_class = FCMDeviceSerializer
 
 


### PR DESCRIPTION
Hey,

In `FCMDeviceViewSet` there is no ordering of queryset currently which leads to inconsistent results when using pagination. This PR is a small fix of that issue

P.S. Final users can obviously redefine this ViewSet and tweak it, but I think it's a good practice to make it work without any warnings from DRF by default.