### PR TITLE
use bash for install instructs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Setup
 -----
 You can install the library directly from pypi using pip:
 
-.. code-block::
+.. code-block:: console
 
     pip install fcm-django
 


### PR DESCRIPTION
instructions on the docs did not show the pip install instructions, this makes the instructions be console explicitly thus allowing them to b rendered in docs