### PR TITLE
Let MySQL pass migrations with unsupported text indexes(#236)

### DIFF
--- a/fcm_django/migrations/0010_unique_registration_id.py
+++ b/fcm_django/migrations/0010_unique_registration_id.py
@@ -2,6 +2,30 @@
 
 from django.db import migrations, models
 
+_MYSQL = "mysql"
+
+
+class AlterFieldSkipMySQL(migrations.AlterField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor == _MYSQL:
+            return
+        super().database_forwards(
+            app_label=app_label,
+            schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+        )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor == _MYSQL:
+            return
+        super().database_forwards(
+            app_label=app_label,
+            schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+        )
+
 
 class Migration(migrations.Migration):
 
@@ -10,7 +34,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        AlterFieldSkipMySQL(
             model_name="fcmdevice",
             name="registration_id",
             field=models.TextField(

--- a/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
+++ b/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
@@ -2,6 +2,30 @@
 
 from django.db import migrations, models
 
+_MYSQL = "mysql"
+
+
+class AddIndexSkipMySQL(migrations.AddIndex):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor == _MYSQL:
+            return
+        super().database_forwards(
+            app_label=app_label,
+            schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+        )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor == _MYSQL:
+            return
+        super().database_forwards(
+            app_label=app_label,
+            schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+        )
+
 
 class Migration(migrations.Migration):
 
@@ -10,7 +34,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddIndex(
+        AddIndexSkipMySQL(
             model_name="fcmdevice",
             index=models.Index(
                 fields=["registration_id", "user"],


### PR DESCRIPTION
Per title, let MySQL continue with non-indexed, non-unique textfield to prioritize following 4kb field standard from Google while letting databases with support have the fancy stuff, unbreaking latest release for MySQL troglodytes.

Tested
- migration forward 0009 to 0011 with MySQL
- migration backward 0011 to 0009 with MySQL
- verified vendor flag is "mysql" per django specs (worked for mariadb as well)
- Only tested in Django 3.2 (per time my time constraint and some reasonable backwards compatibility)
- makemigrations does not trigger in Django 3.2

Risks
- Unique flag behaviour could change in Django releases, causing makemigrations to get triggered by unique=True on FCMDevice

Alternative solutions
- Split FCMDevice into two separate model definitions and move the unique=True flag to the one excluding mysql by using https://docs.djangoproject.com/en/4.2/ref/models/options/#required-db-vendor

