### PR TITLE
Raising the Firebase error instead of returning

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from firebase_admin import initialize_app
 
 
 def pytest_configure():
@@ -15,3 +16,4 @@ def pytest_configure():
             },
         },
     )
+    initialize_app()  # for tests requiring Firebase

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -318,7 +318,7 @@ class AbstractFCMDevice(Device):
             )
         except FirebaseError as e:
             self.deactivate_devices_with_error_result(self.registration_id, e)
-            return e
+            raise e
 
     def handle_topic_subscription(
         self,
@@ -379,7 +379,7 @@ class AbstractFCMDevice(Device):
                 None,
             )
         except FirebaseError as e:
-            return e
+            raise e
 
 
 class FCMDevice(AbstractFCMDevice):

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -373,13 +373,10 @@ class AbstractFCMDevice(Device):
     ) -> Union[Optional[messaging.SendResponse], FirebaseError]:
         message.topic = topic_name
 
-        try:
-            return messaging.SendResponse(
-                {"name": messaging.send(message, app=app, **more_send_message_kwargs)},
-                None,
-            )
-        except FirebaseError as e:
-            raise e
+        return messaging.SendResponse(
+            {"name": messaging.send(message, app=app, **more_send_message_kwargs)},
+            None,
+        )
 
 
 class FCMDevice(AbstractFCMDevice):

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -318,7 +318,7 @@ class AbstractFCMDevice(Device):
             )
         except FirebaseError as e:
             self.deactivate_devices_with_error_result(self.registration_id, e)
-            raise e
+            raise
 
     def handle_topic_subscription(
         self,
@@ -370,7 +370,7 @@ class AbstractFCMDevice(Device):
         topic_name: str,
         app: "firebase_admin.App" = SETTINGS["DEFAULT_FIREBASE_APP"],
         **more_send_message_kwargs,
-    ) -> Union[Optional[messaging.SendResponse], FirebaseError]:
+    ) -> messaging.SendResponse:
         message.topic = topic_name
 
         return messaging.SendResponse(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
 import pytest
+from firebase_admin.exceptions import FirebaseError
+from firebase_admin.messaging import Message
 
 from fcm_django.models import DeviceType, FCMDevice
 
@@ -16,3 +18,21 @@ def test_registration_id_size():
         type=DeviceType.WEB,
     )
     device.save()
+
+
+@pytest.mark.django_db
+def test_firebase_raises(monkeypatch):
+    def _firebase_raises(*args, **kwargs):
+        raise FirebaseError(code=500, message="message")
+
+    monkeypatch.setattr("firebase_admin.messaging.send", _firebase_raises)
+
+    device = FCMDevice(
+        registration_id="test",
+        type=DeviceType.WEB,
+    )
+    with pytest.raises(FirebaseError):
+        device.send_message(message=Message())
+
+    with pytest.raises(FirebaseError):
+        device.send_topic_message(message=Message(), topic_name="topic")


### PR DESCRIPTION
### Issue Description:

- Catching the Firebase error is difficult with the current Implementation.
- The current implementation returns the error instead of raising it.
- Issue link https://github.com/xtrinch/fcm-django/issues/215

### PR Description:

- Raising the error would be the perfect solution so that It can be caught easily inside try/except block.