### PR TITLE
Separate dev and test requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -397,5 +397,5 @@ Submit an issue/PR on this project. Please do not send me emails, as then the co
 Contributing
 ------------
 
-To setup the development environment, simply do ``pip install -r requirements.txt``
+To setup the development environment, simply do ``pip install -r requirements_dev.txt``
 To manually run the pre-commit hook, run `pre-commit run --all-files`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -397,5 +397,5 @@ Submit an issue/PR on this project. Please do not send me emails, as then the co
 Contributing
 ------------
 
-To setup the development environment, simply do ``pip install -r requirements.txt``
+To setup the development environment, simply do ``pip install -r requirements_dev.txt``
 To manually run the pre-commit hook, run `pre-commit run --all-files`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,3 @@ Django>=2.2
 django-tastypie>=0.14.0
 djangorestframework>=3.9.2
 firebase-admin>=5,<7
-
-# Development
-pre-commit>=2.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+-r requirements_test.txt
+
+pre-commit>=2.0.0
+isort==5.12.0
+black==22.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 -r requirements_test.txt
-
-pre-commit>=2.0.0
-isort==5.12.0
 black==22.3.0
+isort==5.12.0
+pre-commit>=2.0.0
 pytest-watcher>=0.3.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ black==22.3.0
 isort==5.12.0
 pre-commit>=2.0.0
 pytest-watcher>=0.3.1
+tox>=4.5.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@
 pre-commit>=2.0.0
 isort==5.12.0
 black==22.3.0
+pytest-watcher>=0.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest>=7.3.1
+pytest-django>=4.5.2
+pytest-mock>=3.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     -rrequirements_test.txt
     djangorestframework>=3.9.2
     django-tastypie>=0.14.0
+    firebase_admin>=5,<7
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ PLATFORM =
 
 [testenv]
 deps =
-    -rrequirements.txt
-    pytest
-    pytest-django
+    -rrequirements_test.txt
+    djangorestframework>=3.9.2
+    django-tastypie>=0.14.0
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
 commands =


### PR DESCRIPTION
I've started to work on writing tests for this project, but first it will be cool to make dependencies management process more convenient. This PR is an attempt to do so.
Brief overview:
- A separate `requirements_test.txt` is used to manage test dependencies that will be used for running tests locally and in CI
- A separate `requirements_dev.txt` is used to manage dev dependencies instead of the general `requirements.txt`. By adding this file we can add development only packages and they **will not** be installed when running `tox` `or cron-update` job. `requirements_test.txt` and `requirements.txt` are sourced inside so this single file will get people covered when setting up local dev enviroment.
- `djangorestframework` and `django-tastypie` are pinned in tox.ini. This is needed because in future we will probably want to run tests against different versions of those libraries to ensure compatibility
- `isort` and `black` are added to `requirements_dev.txt`. This is needed for people who use isort and black plugins in their IDEs. Pinned versions match ones from pre-commit-config.
- `pytest_watcher` and `pytest_mock` packages added for the upcoming testing work