### PR TITLE
depend on actual requirements of application in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ PLATFORM =
 
 [testenv]
 deps =
+    -rrequirements.txt
     -rrequirements_test.txt
-    djangorestframework>=3.9.2
-    django-tastypie>=0.14.0
-    firebase_admin>=5,<7
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
 commands =


### PR DESCRIPTION
This fixes commit https://github.com/xtrinch/fcm-django/commit/3ca790b7a169863cc9775b0c21a59eea421de6d1 which made tests not depend on what the application depends on.