### PR TITLE
fix rollback migration

### DIFF
--- a/fcm_django/migrations/0010_unique_registration_id.py
+++ b/fcm_django/migrations/0010_unique_registration_id.py
@@ -19,7 +19,7 @@ class AlterFieldSkipMySQL(migrations.AlterField):
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if schema_editor.connection.vendor == _MYSQL:
             return
-        super().database_forwards(
+        super().database_backwards(
             app_label=app_label,
             schema_editor=schema_editor,
             from_state=from_state,

--- a/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
+++ b/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
@@ -19,7 +19,7 @@ class AddIndexSkipMySQL(migrations.AddIndex):
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if schema_editor.connection.vendor == _MYSQL:
             return
-        super().database_forwards(
+        super().database_backwards(
             app_label=app_label,
             schema_editor=schema_editor,
             from_state=from_state,


### PR DESCRIPTION
Seems that rollback for non MySQL backends was always broken.

Fix issues introduced by https://github.com/xtrinch/fcm-django/commit/f3699515f97cabb278d6f5d0b98ed73f4f9f3a6d