### PR TITLE
Remove list filter by user from admin.py

### DIFF
--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -30,7 +30,6 @@ class DeviceAdmin(admin.ModelAdmin):
     )
     list_filter = (
         "active",
-        "user",
         "type",
     )
     actions = (


### PR DESCRIPTION
It's better to remove the admin's option to list filter by user. 

When loading the list page, it tries to load and render all options... which are all users. So it gets extremely large and meaningless.

[Source of the problem](https://github.com/xtrinch/fcm-django/pull/221)