### PR TITLE
offer MYSQL_COMPATIBILITY setting to remove unique from the model

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -400,6 +400,7 @@ FCM tokens, but in practice they are less than 200 characters long. Therefore, a
 should be sufficient and you can make it unique and index it even with MySQL:
 
 .. code-block:: python
+
     from fcm_django.models import AbstractFCMDevice, FCMDevice as OriginalFCMDevice
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -372,6 +372,19 @@ logins on the same device, you do not wish the old user to receive messages whil
 Via DRF, any creation of device with an already existing registration ID will be transformed into an update.
 If done manually, you are responsible for deleting the old device entry.
 
+MySQL compatibility
+-------------------
+MySQL has a limit for indices and therefore the `registration_id` field cannot be made unique in MySQL.
+We detect the database backend and remove the unique constraint for MySQL in the migration files. However,
+to ensure that the constraint is removed from the actual model you have to add the following to your settings:
+
+.. code-block:: python
+
+    FCM_DJANGO_SETTINGS = {
+        "MYSQL_COMPATIBILITY": True,
+        # [...] your other settings
+    }
+
 Python 3 support
 ----------------
 - ``fcm-django`` is fully compatible with Python 3.7+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -380,40 +380,6 @@ logins on the same device, you do not wish the old user to receive messages whil
 Via DRF, any creation of device with an already existing registration ID will be transformed into an update.
 If done manually, you are responsible for deleting the old device entry.
 
-MySQL compatibility
--------------------
-MySQL has a limit for indices and therefore the `registration_id` field cannot be made unique in MySQL.
-We detect the database backend and remove the unique constraint for MySQL in the migration files. However,
-to ensure that the constraint is removed from the actual model you have to add the following to your settings
-to be able to run your django tests with MySQL and without running all migrations:
-
-.. code-block:: python
-
-    FCM_DJANGO_SETTINGS = {
-        "MYSQL_COMPATIBILITY": True,
-        # [...] your other settings
-    }
-
-As an alternative, you can use a custom model (see next section) and either remove the unique constraint manually
-or use a length limited CharField for the `registration_id` field. There are no guarantees on the max length of
-FCM tokens, but in practice they are less than 200 characters long. Therefore, a CharField with a length of 600
-should be sufficient and you can make it unique and index it even with MySQL:
-
-.. code-block:: python
-
-    from fcm_django.models import AbstractFCMDevice, FCMDevice as OriginalFCMDevice
-
-
-    class CustomFCMDevice(AbstractFCMDevice):
-        registration_id = models.CharField(
-            verbose_name="Registration token",
-            unique=True,
-            max_length=600,  # https://stackoverflow.com/a/64902685 better to be safe than sorry
-        )
-
-        class Meta(OriginalFCMDevice.Meta):
-            pass
-
 Using custom FCMDevice model
 ----------------------------
 
@@ -481,6 +447,40 @@ that allow to use a `custom User model <https://docs.djangoproject.com/en/4.2/to
 So this functionality have the same limitations.
 The most is important limitation it is that is difficult to start out with a default (non-swapped) model
 and then later to switch to a swapped implementation without doing some migration hacking.
+
+MySQL compatibility
+-------------------
+MySQL has a limit for indices and therefore the `registration_id` field cannot be made unique in MySQL.
+We detect the database backend and remove the unique constraint for MySQL in the migration files. However,
+to ensure that the constraint is removed from the actual model you have to add the following to your settings
+to be able to run your django tests with MySQL and without running all migrations:
+
+.. code-block:: python
+
+    FCM_DJANGO_SETTINGS = {
+        "MYSQL_COMPATIBILITY": True,
+        # [...] your other settings
+    }
+
+As an alternative, you can use a custom model (see above) and either remove the unique constraint manually
+or use a length limited CharField for the `registration_id` field. There are no guarantees on the max length of
+FCM tokens, but in practice they are less than 200 characters long. Therefore, a CharField with a length of 600
+should be sufficient and you can make it unique and index it even with MySQL:
+
+.. code-block:: python
+
+    from fcm_django.models import AbstractFCMDevice, FCMDevice as OriginalFCMDevice
+
+
+    class CustomFCMDevice(AbstractFCMDevice):
+        registration_id = models.CharField(
+            verbose_name="Registration token",
+            unique=True,
+            max_length=600,  # https://stackoverflow.com/a/64902685 better to be safe than sorry
+        )
+
+        class Meta(OriginalFCMDevice.Meta):
+            pass
 
 Python 3 support
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -384,7 +384,8 @@ MySQL compatibility
 -------------------
 MySQL has a limit for indices and therefore the `registration_id` field cannot be made unique in MySQL.
 We detect the database backend and remove the unique constraint for MySQL in the migration files. However,
-to ensure that the constraint is removed from the actual model you have to add the following to your settings:
+to ensure that the constraint is removed from the actual model you have to add the following to your settings
+to be able to run your django tests with MySQL and without running all migrations:
 
 .. code-block:: python
 
@@ -392,6 +393,25 @@ to ensure that the constraint is removed from the actual model you have to add t
         "MYSQL_COMPATIBILITY": True,
         # [...] your other settings
     }
+
+As an alternative, you can use a custom model (see next section) and either remove the unique constraint manually
+or use a length limited CharField for the `registration_id` field. There are no guarantees on the max length of
+FCM tokens, but in practice they are less than 200 characters long. Therefore, a CharField with a length of 600
+should be sufficient and you can make it unique and index it even with MySQL:
+
+.. code-block:: python
+    from fcm_django.models import AbstractFCMDevice, FCMDevice as OriginalFCMDevice
+
+
+    class CustomFCMDevice(AbstractFCMDevice):
+        registration_id = models.CharField(
+            verbose_name="Registration token",
+            unique=True,
+            max_length=600,  # https://stackoverflow.com/a/64902685 better to be safe than sorry
+        )
+
+        class Meta(OriginalFCMDevice.Meta):
+            pass
 
 Using custom FCMDevice model
 ----------------------------
@@ -435,7 +455,7 @@ If you don't want default table appears in the DB then you should remove ``fcm_d
 
 After setup your own ``Model`` don't forget to create ``migrations`` for your app and call ``migrate`` command.
 
-After removing ``"fcm_django"`` out of ``INSTALLED_APPS``. You will need to re-register the Device in order to see it in the admin panel. 
+After removing ``"fcm_django"`` out of ``INSTALLED_APPS``. You will need to re-register the Device in order to see it in the admin panel.
 This can be accomplished as follows at ``your_app/admin.py``:
 
 .. code-block:: python
@@ -455,10 +475,10 @@ If you choose to move forward with swapped models then:
 1. On existed project you have to keep in mind there are required manual work to move data from one table to anther.
 2. If there's any tables with FK to swapped model then you have to deal with them on your own.
 
-Note: This functionality based on `Swapper <https://pypi.org/project/swapper/>`_ that based on functionality 
+Note: This functionality based on `Swapper <https://pypi.org/project/swapper/>`_ that based on functionality
 that allow to use a `custom User model <https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#substituting-a-custom-user-model>`_.
-So this functionality have the same limitations. 
-The most is important limitation it is that is difficult to start out with a default (non-swapped) model 
+So this functionality have the same limitations.
+The most is important limitation it is that is difficult to start out with a default (non-swapped) model
 and then later to switch to a swapped implementation without doing some migration hacking.
 
 Python 3 support
@@ -494,11 +514,11 @@ Because there's possibility to use swapped models therefore tests contains two c
 1. with default settings and non swapped models ``settings/default.py``
 2. and with overwritten settings only that required by swapper - ``settings/swap.py``
 
-To run tests locally you could use ``pytest``, and if you need to check migrations on different DB then you have to specify environment variable ``DATABASE_URL`` ie 
+To run tests locally you could use ``pytest``, and if you need to check migrations on different DB then you have to specify environment variable ``DATABASE_URL`` ie
 
 .. code-block:: console
 
     export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres
-    export DJANGO_SETTINGS_MODULE=tests.settings.default 
+    export DJANGO_SETTINGS_MODULE=tests.settings.default
     # or export DJANGO_SETTINGS_MODULE=tests.settings.swap
     pytest

--- a/fcm_django/migrations/0010_unique_registration_id.py
+++ b/fcm_django/migrations/0010_unique_registration_id.py
@@ -9,7 +9,7 @@ _MYSQL = "mysql"
 
 class AlterFieldSkipMySQL(migrations.AlterField):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
+        if schema_editor.connection.vendor == _MYSQL:
             return
         super().database_forwards(
             app_label=app_label,
@@ -19,7 +19,7 @@ class AlterFieldSkipMySQL(migrations.AlterField):
         )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
+        if schema_editor.connection.vendor == _MYSQL:
             return
         super().database_backwards(
             app_label=app_label,
@@ -44,4 +44,4 @@ class Migration(migrations.Migration):
                 unique=True,
             ),
         ),
-    ]
+    ] if not SETTINGS["MYSQL_COMPATIBILITY"] else []

--- a/fcm_django/migrations/0010_unique_registration_id.py
+++ b/fcm_django/migrations/0010_unique_registration_id.py
@@ -35,13 +35,17 @@ class Migration(migrations.Migration):
         ("fcm_django", "0009_alter_fcmdevice_user"),
     ]
 
-    operations = [
-        AlterFieldSkipMySQL(
-            model_name="fcmdevice",
-            name="registration_id",
-            field=models.TextField(
-                verbose_name="Registration token",
-                unique=True,
+    operations = (
+        [
+            AlterFieldSkipMySQL(
+                model_name="fcmdevice",
+                name="registration_id",
+                field=models.TextField(
+                    verbose_name="Registration token",
+                    unique=True,
+                ),
             ),
-        ),
-    ] if not SETTINGS["MYSQL_COMPATIBILITY"] else []
+        ]
+        if not SETTINGS["MYSQL_COMPATIBILITY"]
+        else []
+    )

--- a/fcm_django/migrations/0010_unique_registration_id.py
+++ b/fcm_django/migrations/0010_unique_registration_id.py
@@ -2,12 +2,14 @@
 
 from django.db import migrations, models
 
+from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
+
 _MYSQL = "mysql"
 
 
 class AlterFieldSkipMySQL(migrations.AlterField):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL:
+        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
             return
         super().database_forwards(
             app_label=app_label,
@@ -17,7 +19,7 @@ class AlterFieldSkipMySQL(migrations.AlterField):
         )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL:
+        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
             return
         super().database_backwards(
             app_label=app_label,

--- a/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
+++ b/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
@@ -2,12 +2,14 @@
 
 from django.db import migrations, models
 
+from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
+
 _MYSQL = "mysql"
 
 
 class AddIndexSkipMySQL(migrations.AddIndex):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL:
+        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
             return
         super().database_forwards(
             app_label=app_label,
@@ -17,7 +19,7 @@ class AddIndexSkipMySQL(migrations.AddIndex):
         )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL:
+        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
             return
         super().database_backwards(
             app_label=app_label,

--- a/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
+++ b/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
@@ -35,12 +35,16 @@ class Migration(migrations.Migration):
         ("fcm_django", "0010_unique_registration_id"),
     ]
 
-    operations = [
-        AddIndexSkipMySQL(
-            model_name="fcmdevice",
-            index=models.Index(
-                fields=["registration_id", "user"],
-                name="fcm_django__registr_dacdb2_idx",
+    operations = (
+        [
+            AddIndexSkipMySQL(
+                model_name="fcmdevice",
+                index=models.Index(
+                    fields=["registration_id", "user"],
+                    name="fcm_django__registr_dacdb2_idx",
+                ),
             ),
-        ),
-    ] if not SETTINGS["MYSQL_COMPATIBILITY"] else []
+        ]
+        if not SETTINGS["MYSQL_COMPATIBILITY"]
+        else []
+    )

--- a/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
+++ b/fcm_django/migrations/0011_fcmdevice_fcm_django_registration_id_user_id_idx.py
@@ -9,7 +9,7 @@ _MYSQL = "mysql"
 
 class AddIndexSkipMySQL(migrations.AddIndex):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
+        if schema_editor.connection.vendor == _MYSQL:
             return
         super().database_forwards(
             app_label=app_label,
@@ -19,7 +19,7 @@ class AddIndexSkipMySQL(migrations.AddIndex):
         )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        if schema_editor.connection.vendor == _MYSQL or SETTINGS["MYSQL_COMPATIBILITY"]:
+        if schema_editor.connection.vendor == _MYSQL:
             return
         super().database_backwards(
             app_label=app_label,
@@ -43,4 +43,4 @@ class Migration(migrations.Migration):
                 name="fcm_django__registr_dacdb2_idx",
             ),
         ),
-    ]
+    ] if not SETTINGS["MYSQL_COMPATIBILITY"] else []

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -277,7 +277,7 @@ class AbstractFCMDevice(Device):
     )
     registration_id = models.TextField(
         verbose_name=_("Registration token"),
-        unique=True,
+        unique=not SETTINGS["MYSQL_COMPATIBILITY"],
     )
     type = models.CharField(choices=DeviceType.choices, max_length=10)
     objects: "FCMDeviceQuerySet" = FCMDeviceManager()
@@ -389,6 +389,7 @@ class FCMDevice(AbstractFCMDevice):
         verbose_name = _("FCM device")
         verbose_name_plural = _("FCM devices")
 
-        indexes = [
-            models.Index(fields=["registration_id", "user"]),
-        ]
+        if not SETTINGS["MYSQL_COMPATIBILITY"]:
+            indexes = [
+                models.Index(fields=["registration_id", "user"]),
+            ]

--- a/fcm_django/settings.py
+++ b/fcm_django/settings.py
@@ -24,3 +24,6 @@ FCM_DJANGO_SETTINGS.setdefault(
         "invalid_package_name": "InvalidPackageName",
     },
 )
+
+# MySQL compatibility
+FCM_DJANGO_SETTINGS.setdefault("MYSQL_COMPATIBILITY", False)


### PR DESCRIPTION
Fixes https://github.com/xtrinch/fcm-django/issues/266. Funny enough I just saw the commit with the swappable model and it seems possible to do this now:

```
class CustomFCMDevice(AbstractFCMDevice):
    registration_id = models.CharField(  # https://github.com/xtrinch/fcm-django/issues/266
        verbose_name="Registration token",
        unique=True,
        max_length=600,  # https://stackoverflow.com/a/64902685 better to be safe than sorry
    )

    class Meta(OriginalFCMDevice.Meta):
        pass
```

with setting `FCM_DJANGO_FCMDEVICE_MODEL = '...CustomFCMDevice'`.