### PR TITLE
refactor: load firebase_admin lazily

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -501,10 +501,47 @@ In your ``settings.py``:
 The callable is invoked lazily on the first ``send_message``, ``handle_topic_subscription``,
 or ``send_topic_message`` call. The resulting app is cached for subsequent operations.
 
+This also works with custom credentials classes:
+
+.. code-block:: python
+
+    import os
+
+    def initialize_firebase():
+        from firebase_admin import initialize_app, credentials
+        from google.auth import load_credentials_from_file
+
+        class CustomFirebaseCredentials(credentials.ApplicationDefault):
+            def __init__(self, account_file_path: str):
+                super().__init__()
+                self._account_file_path = account_file_path
+
+            def _load_credential(self):
+                if not self._g_credential:
+                    self._g_credential, self._project_id = load_credentials_from_file(
+                        self._account_file_path,
+                        scopes=credentials._scopes
+                    )
+
+        custom_credentials = CustomFirebaseCredentials(
+            os.getenv('CUSTOM_GOOGLE_APPLICATION_CREDENTIALS')
+        )
+        return initialize_app(custom_credentials, name='messaging')
+
+    FCM_DJANGO_SETTINGS = {
+        "INITIALIZE_APP_CALLABLE": initialize_firebase,
+        # [...] your other settings
+    }
+
 Your callable must either:
 
 - Return a ``firebase_admin.App`` instance, or
 - Call ``initialize_app()`` (the default app will be retrieved automatically)
+
+The returned app is cached and used as the default for all subsequent fcm-django operations.
+Because of this, you should use either ``DEFAULT_FIREBASE_APP`` or ``INITIALIZE_APP_CALLABLE``,
+but not both. If both are set, ``DEFAULT_FIREBASE_APP`` takes priority and the callable is
+never invoked.
 
 
 Django REST Framework (DRF) support

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Edit your settings.py file:
          # a callable that initializes and returns a firebase_admin.App
          # called lazily on first FCM operation; result is cached
          # default: None
-        "INITIALIZE_APP_CALLABLE": None,
+        "FIREBASE_APP_INITIALIZER": None,
          # default: _('FCM Django')
         "APP_VERBOSE_NAME": "[string for AppConfig's verbose_name]",
          # true if you want to have only one active device per registered user at a time
@@ -478,7 +478,7 @@ Lazy Firebase app initialization
 --------------------------------
 
 If you need to defer Firebase initialization until the first FCM operation (e.g., when
-credentials aren't available at import time), use the ``INITIALIZE_APP_CALLABLE`` setting
+credentials aren't available at import time), use the ``FIREBASE_APP_INITIALIZER`` setting
 instead of calling ``initialize_app()`` at the top of your settings file.
 
 In your ``settings.py``:
@@ -494,7 +494,7 @@ In your ``settings.py``:
         return initialize_app(cred)
 
     FCM_DJANGO_SETTINGS = {
-        "INITIALIZE_APP_CALLABLE": initialize_firebase,
+        "FIREBASE_APP_INITIALIZER": initialize_firebase,
         # [...] your other settings
     }
 
@@ -529,7 +529,7 @@ This also works with custom credentials classes:
         return initialize_app(custom_credentials, name='messaging')
 
     FCM_DJANGO_SETTINGS = {
-        "INITIALIZE_APP_CALLABLE": initialize_firebase,
+        "FIREBASE_APP_INITIALIZER": initialize_firebase,
         # [...] your other settings
     }
 
@@ -539,7 +539,7 @@ Your callable must either:
 - Call ``initialize_app()`` (the default app will be retrieved automatically)
 
 The returned app is cached and used as the default for all subsequent fcm-django operations.
-Because of this, you should use either ``DEFAULT_FIREBASE_APP`` or ``INITIALIZE_APP_CALLABLE``,
+Because of this, you should use either ``DEFAULT_FIREBASE_APP`` or ``FIREBASE_APP_INITIALIZER``,
 but not both. If both are set, ``DEFAULT_FIREBASE_APP`` takes priority and the callable is
 never invoked.
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,10 @@ Edit your settings.py file:
          # an instance of firebase_admin.App to be used as default for all fcm-django requests
          # default: None (the default Firebase app)
         "DEFAULT_FIREBASE_APP": None,
+         # a callable that initializes and returns a firebase_admin.App
+         # called lazily on first FCM operation; result is cached
+         # default: None
+        "INITIALIZE_APP_CALLABLE": None,
          # default: _('FCM Django')
         "APP_VERBOSE_NAME": "[string for AppConfig's verbose_name]",
          # true if you want to have only one active device per registered user at a time
@@ -469,6 +473,38 @@ In your ``settings.py``:
         "DEFAULT_FIREBASE_APP": FIREBASE_MESSAGING_APP,
         # [...] your other settings
     }
+
+Lazy Firebase app initialization
+--------------------------------
+
+If you need to defer Firebase initialization until the first FCM operation (e.g., when
+credentials aren't available at import time), use the ``INITIALIZE_APP_CALLABLE`` setting
+instead of calling ``initialize_app()`` at the top of your settings file.
+
+In your ``settings.py``:
+
+.. code-block:: python
+
+    import os
+
+    def initialize_firebase():
+        from firebase_admin import initialize_app, credentials
+
+        cred = credentials.Certificate(os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+        return initialize_app(cred)
+
+    FCM_DJANGO_SETTINGS = {
+        "INITIALIZE_APP_CALLABLE": initialize_firebase,
+        # [...] your other settings
+    }
+
+The callable is invoked lazily on the first ``send_message``, ``handle_topic_subscription``,
+or ``send_topic_message`` call. The resulting app is cached for subsequent operations.
+
+Your callable must either:
+
+- Return a ``firebase_admin.App`` instance, or
+- Call ``initialize_app()`` (the default app will be retrieved automatically)
 
 
 Django REST Framework (DRF) support

--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -12,11 +12,10 @@ from django.contrib import admin, messages
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext_lazy
 
+from fcm_django.firebase import firebase_error_type, firebase_messaging
 from fcm_django.models import _get_fcm_error_list
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.types import FirebaseResponseDict
-
-# firebase_admin imports moved to where they're used to avoid eager loading
 
 
 User = apps.get_model(*SETTINGS["USER_MODEL"].split("."))
@@ -93,7 +92,7 @@ class DeviceAdmin(admin.ModelAdmin):
         )
 
         def _get_to_str_obj(obj):
-            from firebase_admin import messaging
+            messaging = firebase_messaging()
 
             if isinstance(obj, messaging.SendResponse):
                 return obj.exception
@@ -102,7 +101,7 @@ class DeviceAdmin(admin.ModelAdmin):
             return obj
 
         def _print_responses(_response):
-            from firebase_admin import messaging
+            messaging = firebase_messaging()
 
             __error_list = _get_fcm_error_list() + [messaging.ErrorInfo]
             # TODO Aggregate error response text. Each firebase error
@@ -142,10 +141,8 @@ class DeviceAdmin(admin.ModelAdmin):
         total_failure = 0
         single_responses: list[tuple["SendResponse", str]] = []
 
-        from firebase_admin import messaging
-        from firebase_admin.exceptions import FirebaseError
-
         try:
+            messaging = firebase_messaging()
             for device in queryset:
                 device: "FCMDevice"
                 if bulk:
@@ -172,9 +169,11 @@ class DeviceAdmin(admin.ModelAdmin):
                     single_responses.append((response, device.registration_id))
                     if type(response) != messaging.SendResponse:
                         total_failure += 1
-        except FirebaseError as exc:
-            self.message_user(request, str(exc), level=messages.ERROR)
-            return
+        except Exception as exc:
+            if isinstance(exc, firebase_error_type()):
+                self.message_user(request, str(exc), level=messages.ERROR)
+                return
+            raise
 
         self._send_deactivated_message(request, single_responses, total_failure, False)
 
@@ -251,10 +250,8 @@ class DeviceAdmin(admin.ModelAdmin):
     bulk_unsubscribe_to_topic.short_description = _("Unsubscribe to test topic in bulk")
 
     def handle_send_topic_message(self, request, queryset):
-        from firebase_admin import messaging
-        from firebase_admin.exceptions import FirebaseError
-
         try:
+            messaging = firebase_messaging()
             FCMDevice.send_topic_message(
                 messaging.Message(
                     notification=messaging.Notification(
@@ -263,8 +260,11 @@ class DeviceAdmin(admin.ModelAdmin):
                 ),
                 "test-topic",
             )
-        except FirebaseError as exc:
-            self.message_user(request, str(exc), level=messages.ERROR)
+        except Exception as exc:
+            if isinstance(exc, firebase_error_type()):
+                self.message_user(request, str(exc), level=messages.ERROR)
+                return
+            raise
 
     def send_topic_message(self, request, queryset):
         self.handle_send_topic_message(request, queryset)

--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -63,7 +63,7 @@ class DeviceAdmin(admin.ModelAdmin):
         response: Union[
             FirebaseResponseDict,
             list[FirebaseResponseDict],
-            list[tuple["SendResponse", str]],
+            list[tuple[SendResponse, str]],
         ],
         total_failure: int,
         is_topic: bool,
@@ -139,12 +139,11 @@ class DeviceAdmin(admin.ModelAdmin):
         send_bulk_message methods.
         """
         total_failure = 0
-        single_responses: list[tuple["SendResponse", str]] = []
-
+        single_responses: list[tuple[SendResponse, str]] = []
         try:
             messaging = firebase_messaging()
             for device in queryset:
-                device: "FCMDevice"
+                device: FCMDevice
                 if bulk:
                     response = queryset.send_message(
                         messaging.Message(
@@ -200,7 +199,7 @@ class DeviceAdmin(admin.ModelAdmin):
         for device in queryset:
             device: "FCMDevice"
             if bulk:
-                response: "FirebaseResponseDict" = queryset.handle_topic_subscription(
+                response: FirebaseResponseDict = queryset.handle_topic_subscription(
                     should_subscribe,
                     "test-topic",
                 )

--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -6,6 +6,7 @@ import swapper
 
 if TYPE_CHECKING:
     from firebase_admin.messaging import SendResponse
+
 from django.apps import apps
 from django.contrib import admin, messages
 from django.utils.translation import gettext_lazy as _
@@ -14,6 +15,9 @@ from django.utils.translation import ngettext_lazy
 from fcm_django.models import _get_fcm_error_list
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.types import FirebaseResponseDict
+
+# firebase_admin imports moved to where they're used to avoid eager loading
+
 
 User = apps.get_model(*SETTINGS["USER_MODEL"].split("."))
 

--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -17,7 +17,6 @@ from fcm_django.models import _get_fcm_error_list
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.types import FirebaseResponseDict
 
-
 User = apps.get_model(*SETTINGS["USER_MODEL"].split("."))
 
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
@@ -60,11 +59,11 @@ class DeviceAdmin(admin.ModelAdmin):
     def _send_deactivated_message(
         self,
         request,
-        response: Union[
-            FirebaseResponseDict,
-            list[FirebaseResponseDict],
-            list[tuple[SendResponse, str]],
-        ],
+        response: (
+            FirebaseResponseDict
+            | list[FirebaseResponseDict]
+            | list[tuple[SendResponse, str]]
+        ),
         total_failure: int,
         is_topic: bool,
     ):
@@ -197,7 +196,7 @@ class DeviceAdmin(admin.ModelAdmin):
         single_responses = []
 
         for device in queryset:
-            device: "FCMDevice"
+            device: FCMDevice
             if bulk:
                 response: FirebaseResponseDict = queryset.handle_topic_subscription(
                     should_subscribe,

--- a/fcm_django/admin.py
+++ b/fcm_django/admin.py
@@ -1,20 +1,17 @@
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
 
 import swapper
+
+if TYPE_CHECKING:
+    from firebase_admin.messaging import SendResponse
 from django.apps import apps
 from django.contrib import admin, messages
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext_lazy
-from firebase_admin.exceptions import FirebaseError
-from firebase_admin.messaging import (
-    ErrorInfo,
-    Message,
-    Notification,
-    SendResponse,
-    TopicManagementResponse,
-)
 
-from fcm_django.models import fcm_error_list
+from fcm_django.models import _get_fcm_error_list
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.types import FirebaseResponseDict
 
@@ -63,7 +60,7 @@ class DeviceAdmin(admin.ModelAdmin):
         response: Union[
             FirebaseResponseDict,
             list[FirebaseResponseDict],
-            list[tuple[SendResponse, str]],
+            list[tuple["SendResponse", str]],
         ],
         total_failure: int,
         is_topic: bool,
@@ -92,14 +89,18 @@ class DeviceAdmin(admin.ModelAdmin):
         )
 
         def _get_to_str_obj(obj):
-            if isinstance(obj, SendResponse):
+            from firebase_admin import messaging
+
+            if isinstance(obj, messaging.SendResponse):
                 return obj.exception
-            elif isinstance(obj, TopicManagementResponse):
+            elif isinstance(obj, messaging.TopicManagementResponse):
                 return obj.errors
             return obj
 
         def _print_responses(_response):
-            __error_list = fcm_error_list + [ErrorInfo]
+            from firebase_admin import messaging
+
+            __error_list = _get_fcm_error_list() + [messaging.ErrorInfo]
             # TODO Aggregate error response text. Each firebase error
             #  has multiple response texts too
             [
@@ -135,15 +136,18 @@ class DeviceAdmin(admin.ModelAdmin):
         send_bulk_message methods.
         """
         total_failure = 0
-        single_responses: list[tuple[SendResponse, str]] = []
+        single_responses: list[tuple["SendResponse", str]] = []
+
+        from firebase_admin import messaging
+        from firebase_admin.exceptions import FirebaseError
 
         try:
             for device in queryset:
                 device: "FCMDevice"
                 if bulk:
                     response = queryset.send_message(
-                        Message(
-                            notification=Notification(
+                        messaging.Message(
+                            notification=messaging.Notification(
                                 title="Test notification", body="Test bulk notification"
                             )
                         )
@@ -154,15 +158,15 @@ class DeviceAdmin(admin.ModelAdmin):
                     )
                 else:
                     response = device.send_message(
-                        Message(
-                            notification=Notification(
+                        messaging.Message(
+                            notification=messaging.Notification(
                                 title="Test notification",
                                 body="Test single notification",
                             )
                         )
                     )
                     single_responses.append((response, device.registration_id))
-                    if type(response) != SendResponse:
+                    if type(response) != messaging.SendResponse:
                         total_failure += 1
         except FirebaseError as exc:
             self.message_user(request, str(exc), level=messages.ERROR)
@@ -243,10 +247,13 @@ class DeviceAdmin(admin.ModelAdmin):
     bulk_unsubscribe_to_topic.short_description = _("Unsubscribe to test topic in bulk")
 
     def handle_send_topic_message(self, request, queryset):
+        from firebase_admin import messaging
+        from firebase_admin.exceptions import FirebaseError
+
         try:
             FCMDevice.send_topic_message(
-                Message(
-                    notification=Notification(
+                messaging.Message(
+                    notification=messaging.Notification(
                         title="Test notification", body="Test single notification"
                     )
                 ),

--- a/fcm_django/firebase.py
+++ b/fcm_django/firebase.py
@@ -1,0 +1,67 @@
+from typing import TYPE_CHECKING
+
+from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
+
+if TYPE_CHECKING:
+    import firebase_admin
+    from firebase_admin import messaging
+
+
+_cached_app = None
+
+
+def firebase_messaging():
+    from firebase_admin import messaging
+
+    return messaging
+
+
+def firebase_error_type():
+    from firebase_admin.exceptions import FirebaseError
+
+    return FirebaseError
+
+
+def invalid_argument_error_type():
+    from firebase_admin.exceptions import InvalidArgumentError
+
+    return InvalidArgumentError
+
+
+def get_app(app: "firebase_admin.App" = None):
+    """Resolve the Firebase app, initializing it lazily if configured."""
+    global _cached_app
+
+    if app is not None:
+        return app
+
+    if SETTINGS.get("DEFAULT_FIREBASE_APP") is not None:
+        return SETTINGS["DEFAULT_FIREBASE_APP"]
+
+    if _cached_app is not None:
+        return _cached_app
+
+    from firebase_admin import get_app as firebase_get_app
+
+    try:
+        _cached_app = firebase_get_app()
+        return _cached_app
+    except ValueError:
+        pass
+
+    init_callable = SETTINGS.get("INITIALIZE_APP_CALLABLE")
+    if not init_callable:
+        return None
+
+    result = init_callable()
+    if result is not None:
+        _cached_app = result
+        return _cached_app
+
+    try:
+        _cached_app = firebase_get_app()
+        return _cached_app
+    except ValueError:
+        raise ValueError(
+            "INITIALIZE_APP_CALLABLE must return an App or call initialize_app()"
+        )

--- a/fcm_django/firebase.py
+++ b/fcm_django/firebase.py
@@ -49,7 +49,7 @@ def get_app(app: "firebase_admin.App" = None):
     except ValueError:
         pass
 
-    init_callable = SETTINGS.get("INITIALIZE_APP_CALLABLE")
+    init_callable = SETTINGS.get("FIREBASE_APP_INITIALIZER")
     if not init_callable:
         return None
 
@@ -63,5 +63,5 @@ def get_app(app: "firebase_admin.App" = None):
         return _cached_app
     except ValueError:
         raise ValueError(
-            "INITIALIZE_APP_CALLABLE must return an App or call initialize_app()"
+            "FIREBASE_APP_INITIALIZER must return an App or call initialize_app()"
         )

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -29,6 +29,7 @@ from fcm_django.types import DeviceDeactivationData, FirebaseResponseDict
 MAX_MESSAGES_PER_BATCH = 500
 MAX_DEVICES_PER_SUBSCRIBE_REQUEST = 1000
 
+
 class Device(models.Model):
     id = models.AutoField(
         verbose_name="ID",
@@ -134,9 +135,9 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         registration_ids: list[str],
         title_template: str,
         body_template: str,
-        message_data: Optional[dict[str, dict[str, Any]]] = None,
-        data_fields: Optional[dict[str, Any]] = None,
-    ) -> list["messaging.Message"]:
+        message_data: dict[str, dict[str, Any]] | None = None,
+        data_fields: dict[str, Any] | None = None,
+    ) -> list[messaging.Message]:
         from firebase_admin import messaging
 
         messages = []
@@ -159,7 +160,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
     def _get_deactivation_candidates(
         registration_ids: list[str],
-        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
+        results: list[messaging.SendResponse | messaging.ErrorInfo],
     ) -> list[str]:
         if not results:
             return []
@@ -275,10 +276,10 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     async def asend_message(
         self,
-        message: "messaging.Message",
+        message: messaging.Message,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App | None = None,
         **more_send_message_kwargs,
     ) -> FirebaseResponseDict:
         registration_ids = await self.aget_registration_ids(
@@ -374,11 +375,11 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         self,
         title_template: str,
         body_template: str,
-        message_data: Optional[dict[str, dict[str, Any]]] = None,
-        data_fields: Optional[dict[str, Any]] = None,
+        message_data: dict[str, dict[str, Any]] | None = None,
+        data_fields: dict[str, Any] | None = None,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App | None = None,
         **more_send_message_kwargs,
     ) -> FirebaseResponseDict:
         registration_ids = await self.aget_registration_ids(
@@ -438,7 +439,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         *,
         reason: str,
         source: str,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> list[str]:
         active_devices = self.filter(active=True)
         device_rows = [
@@ -483,7 +484,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     async def adeactivate_devices_with_error_results(
         self,
         registration_ids: list[str],
-        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
+        results: list[messaging.SendResponse | messaging.ErrorInfo],
     ) -> list[str]:
         deactivation_candidates = self._get_deactivation_candidates(
             registration_ids, results

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from fcm_django.firebase import (
+    firebase_error_type,
+    firebase_messaging,
+    get_app,
+    invalid_argument_error_type,
+)
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.signals import device_deactivated
 from fcm_django.types import DeviceDeactivationData, FirebaseResponseDict
@@ -22,51 +28,6 @@ from fcm_django.types import DeviceDeactivationData, FirebaseResponseDict
 # upgrade package in time via a monkeypatch.
 MAX_MESSAGES_PER_BATCH = 500
 MAX_DEVICES_PER_SUBSCRIBE_REQUEST = 1000
-
-# firebase_admin imports moved to where they're used to avoid eager loading
-
-_cached_app = None
-
-
-def _get_app(app=None):
-    """Get Firebase app, initializing lazily if INITIALIZE_APP_CALLABLE is set."""
-    global _cached_app
-
-    if app is not None:
-        return app
-
-    if _cached_app is not None:
-        return _cached_app
-
-    if SETTINGS.get("DEFAULT_FIREBASE_APP") is not None:
-        _cached_app = SETTINGS["DEFAULT_FIREBASE_APP"]
-        return _cached_app
-
-    from firebase_admin import get_app
-
-    try:
-        _cached_app = get_app()
-        return _cached_app
-    except ValueError:
-        pass
-
-    init_callable = SETTINGS.get("INITIALIZE_APP_CALLABLE")
-    if not init_callable:
-        return None
-
-    result = init_callable()
-    if result is not None:
-        _cached_app = result
-        return _cached_app
-
-    try:
-        _cached_app = get_app()
-        return _cached_app
-    except ValueError:
-        raise ValueError(
-            "INITIALIZE_APP_CALLABLE must return an App or call initialize_app()"
-        )
-
 
 class Device(models.Model):
     id = models.AutoField(
@@ -111,7 +72,7 @@ class _FCMDeviceManager(models.Manager):
 
 # Error codes: https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
 def _get_fcm_error_list():
-    from firebase_admin import messaging
+    messaging = firebase_messaging()
 
     return [
         messaging.UnregisteredError,
@@ -124,7 +85,7 @@ def _get_fcm_error_list_str():
 
 
 def _validate_exception_for_deactivation(exc: Union["FirebaseError"]) -> bool:
-    from firebase_admin.exceptions import InvalidArgumentError
+    InvalidArgumentError = invalid_argument_error_type()
 
     if not exc:
         return False
@@ -152,7 +113,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def get_default_send_message_response() -> FirebaseResponseDict:
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         return FirebaseResponseDict(
             response=messaging.BatchResponse([]),
@@ -284,7 +245,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
-        app = _get_app(app)
+        app = get_app(app)
         registration_ids = self.get_registration_ids(
             skip_registration_id_lookup,
             additional_registration_ids,
@@ -292,7 +253,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_send_message_response()
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
             messages = [
@@ -384,9 +345,10 @@ class FCMDeviceQuerySet(models.query.QuerySet):
             additional_registration_ids,
         )
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
+        app = get_app(app)
         if not registration_ids:
             return self.get_default_send_message_response()
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
@@ -551,7 +513,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     def _get_failed_exception_codes(
         results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
     ) -> list[str]:
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         failed_exceptions = []
 
@@ -593,7 +555,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def get_default_topic_response() -> FirebaseResponseDict:
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         return FirebaseResponseDict(
             response=messaging.TopicManagementResponse({"results": []}),
@@ -631,7 +593,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
-        app = _get_app(app)
+        app = get_app(app)
         registration_ids = self.get_registration_ids(
             skip_registration_id_lookup,
             additional_registration_ids,
@@ -639,7 +601,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_topic_response()
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_DEVICES_PER_SUBSCRIBE_REQUEST):
@@ -711,9 +673,8 @@ class AbstractFCMDevice(Device):
         :returns messaging.SendResponse or FirebaseError if the device was
         deactivated due to an error.
         """
-        from firebase_admin import messaging
-
-        app = _get_app(app)
+        messaging = firebase_messaging()
+        app = get_app(app)
 
         if not self.active:
             return messaging.SendResponse(
@@ -728,9 +689,7 @@ class AbstractFCMDevice(Device):
                 None,
             )
         except Exception as e:
-            from firebase_admin.exceptions import FirebaseError
-
-            if isinstance(e, FirebaseError):
+            if isinstance(e, firebase_error_type()):
                 self.deactivate_devices_with_error_result(self.registration_id, e)
             raise
 
@@ -756,9 +715,8 @@ class AbstractFCMDevice(Device):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
-        from firebase_admin import messaging
-
-        app = _get_app(app)
+        messaging = firebase_messaging()
+        app = get_app(app)
         _r_ids = [self.registration_id]
 
         response = (
@@ -778,7 +736,7 @@ class AbstractFCMDevice(Device):
     def deactivate_devices_with_error_result(
         cls, registration_id, firebase_exc, name=None
     ) -> list[str]:
-        from firebase_admin import messaging
+        messaging = firebase_messaging()
 
         return cls.objects.deactivate_devices_with_error_results(
             [registration_id], [messaging.SendResponse({"name": name}, firebase_exc)]
@@ -790,10 +748,9 @@ class AbstractFCMDevice(Device):
         topic_name: str,
         app: Optional["firebase_admin.App"] = None,
         **more_send_message_kwargs,
-    ) -> messaging.SendResponse:
-        from firebase_admin import messaging
-
-        app = _get_app(app)
+    ) -> "messaging.SendResponse":
+        messaging = firebase_messaging()
+        app = get_app(app)
         message.topic = topic_name
 
         return messaging.SendResponse(

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -23,6 +23,8 @@ from fcm_django.types import DeviceDeactivationData, FirebaseResponseDict
 MAX_MESSAGES_PER_BATCH = 500
 MAX_DEVICES_PER_SUBSCRIBE_REQUEST = 1000
 
+# firebase_admin imports moved to where they're used to avoid eager loading
+
 
 class Device(models.Model):
     id = models.AutoField(
@@ -109,6 +111,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
     def get_default_send_message_response() -> FirebaseResponseDict:
         from firebase_admin import messaging
+
         return FirebaseResponseDict(
             response=messaging.BatchResponse([]),
             registration_ids_sent=[],
@@ -548,6 +551,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
     def get_default_topic_response() -> FirebaseResponseDict:
         from firebase_admin import messaging
+
         return FirebaseResponseDict(
             response=messaging.TopicManagementResponse({"results": []}),
             registration_ids_sent=[],
@@ -664,6 +668,7 @@ class AbstractFCMDevice(Device):
         deactivated due to an error.
         """
         from firebase_admin import messaging
+
         if not self.active:
             return messaging.SendResponse(
                 None,
@@ -678,6 +683,7 @@ class AbstractFCMDevice(Device):
             )
         except Exception as e:
             from firebase_admin.exceptions import FirebaseError
+
             if isinstance(e, FirebaseError):
                 self.deactivate_devices_with_error_result(self.registration_id, e)
             raise
@@ -707,6 +713,7 @@ class AbstractFCMDevice(Device):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         _r_ids = [self.registration_id]
         from firebase_admin import messaging
+
         response = (
             messaging.subscribe_to_topic
             if should_subscribe

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from copy import copy
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import swapper
 from asgiref.sync import sync_to_async
+
+if TYPE_CHECKING:
+    import firebase_admin
+    from firebase_admin import messaging
+    from firebase_admin.exceptions import FirebaseError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from firebase_admin import messaging
-from firebase_admin.exceptions import FirebaseError, InvalidArgumentError
 
 from fcm_django.settings import FCM_DJANGO_SETTINGS as SETTINGS
 from fcm_django.signals import device_deactivated
@@ -61,26 +66,33 @@ class _FCMDeviceManager(models.Manager):
 
 
 # Error codes: https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
-fcm_error_list = [
-    messaging.UnregisteredError,
-    messaging.SenderIdMismatchError,
-]
+def _get_fcm_error_list():
+    from firebase_admin import messaging
 
-fcm_error_list_str = [x.code for x in fcm_error_list]
+    return [
+        messaging.UnregisteredError,
+        messaging.SenderIdMismatchError,
+    ]
 
 
-def _validate_exception_for_deactivation(exc: Union[FirebaseError]) -> bool:
+def _get_fcm_error_list_str():
+    return [x.code for x in _get_fcm_error_list()]
+
+
+def _validate_exception_for_deactivation(exc: Union["FirebaseError"]) -> bool:
+    from firebase_admin.exceptions import InvalidArgumentError
+
     if not exc:
         return False
     exc_type = type(exc)
     if exc_type == str:
-        return exc in fcm_error_list_str
+        return exc in _get_fcm_error_list_str()
     # INVALID_ARGUMENT is broader than token invalidation. Only deactivate for the
     # explicit invalid-registration cause; other causes such as invalid TTL or
     # malformed payload parameters should leave the device active.
     return (
         exc_type == InvalidArgumentError and exc.cause == "Invalid registration"
-    ) or (exc_type in fcm_error_list)
+    ) or (exc_type in _get_fcm_error_list())
 
 
 class _MissingFormatDict(dict[str, Any]):
@@ -90,12 +102,13 @@ class _MissingFormatDict(dict[str, Any]):
 
 class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
-    def _prepare_message(message: messaging.Message, token: str):
+    def _prepare_message(message: "messaging.Message", token: str):
         message.token = token
         return copy(message)
 
     @staticmethod
     def get_default_send_message_response() -> FirebaseResponseDict:
+        from firebase_admin import messaging
         return FirebaseResponseDict(
             response=messaging.BatchResponse([]),
             registration_ids_sent=[],
@@ -117,7 +130,9 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         body_template: str,
         message_data: Optional[dict[str, dict[str, Any]]] = None,
         data_fields: Optional[dict[str, Any]] = None,
-    ) -> list[messaging.Message]:
+    ) -> list["messaging.Message"]:
+        from firebase_admin import messaging
+
         messages = []
         for token in registration_ids:
             template_data = message_data.get(token) if message_data else None
@@ -138,10 +153,12 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
     def _get_deactivation_candidates(
         registration_ids: list[str],
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
     ) -> list[str]:
         if not results:
             return []
+        from firebase_admin import messaging
+
         if isinstance(results[0], messaging.SendResponse):
             return [
                 token
@@ -196,7 +213,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     def send_message(
         self,
-        message: messaging.Message,
+        message: "messaging.Message",
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
         app: Optional["firebase_admin.App"] = None,
@@ -229,6 +246,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_send_message_response()
+        from firebase_admin import messaging
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
             messages = [
@@ -250,7 +268,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     async def asend_message(
         self,
-        message: messaging.Message,
+        message: "messaging.Message",
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
         app: Optional["firebase_admin.App"] = None,
@@ -263,6 +281,8 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_send_message_response()
+        from firebase_admin import messaging
+
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
             messages = [
@@ -320,6 +340,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_send_message_response()
+        from firebase_admin import messaging
 
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
@@ -359,6 +380,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_send_message_response()
+        from firebase_admin import messaging
 
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_MESSAGES_PER_BATCH):
@@ -432,7 +454,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     def deactivate_devices_with_error_results(
         self,
         registration_ids: list[str],
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
     ) -> list[str]:
         deactivation_candidates = self._get_deactivation_candidates(
             registration_ids, results
@@ -453,7 +475,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     async def adeactivate_devices_with_error_results(
         self,
         registration_ids: list[str],
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
     ) -> list[str]:
         deactivation_candidates = self._get_deactivation_candidates(
             registration_ids, results
@@ -481,8 +503,10 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def _get_failed_exception_codes(
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
     ) -> list[str]:
+        from firebase_admin import messaging
+
         failed_exceptions = []
 
         for item in results:
@@ -523,6 +547,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def get_default_topic_response() -> FirebaseResponseDict:
+        from firebase_admin import messaging
         return FirebaseResponseDict(
             response=messaging.TopicManagementResponse({"results": []}),
             registration_ids_sent=[],
@@ -566,6 +591,8 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         if not registration_ids:
             return self.get_default_topic_response()
+        from firebase_admin import messaging
+
         responses: list[messaging.SendResponse] = []
         for i in range(0, len(registration_ids), MAX_DEVICES_PER_SUBSCRIBE_REQUEST):
             batch_ids = registration_ids[i : i + MAX_DEVICES_PER_SUBSCRIBE_REQUEST]
@@ -574,7 +601,6 @@ class FCMDeviceQuerySet(models.query.QuerySet):
                 if should_subscribe
                 else messaging.unsubscribe_from_topic
             )(batch_ids, topic, app=app, **more_subscribe_kwargs)
-
         return FirebaseResponseDict(
             response=messaging.BatchResponse(responses),
             registration_ids_sent=registration_ids,
@@ -618,10 +644,10 @@ class AbstractFCMDevice(Device):
 
     def send_message(
         self,
-        message: messaging.Message,
+        message: "messaging.Message",
         app: Optional["firebase_admin.App"] = None,
         **more_send_message_kwargs,
-    ) -> messaging.SendResponse:
+    ) -> "messaging.SendResponse":
         """
         Send single message. The message's token should be blank (and will be
         overridden if not). Responds with message ID string.
@@ -637,6 +663,7 @@ class AbstractFCMDevice(Device):
         :returns messaging.SendResponse or FirebaseError if the device was
         deactivated due to an error.
         """
+        from firebase_admin import messaging
         if not self.active:
             return messaging.SendResponse(
                 None,
@@ -649,8 +676,10 @@ class AbstractFCMDevice(Device):
                 {"name": messaging.send(message, app=app, **more_send_message_kwargs)},
                 None,
             )
-        except FirebaseError as e:
-            self.deactivate_devices_with_error_result(self.registration_id, e)
+        except Exception as e:
+            from firebase_admin.exceptions import FirebaseError
+            if isinstance(e, FirebaseError):
+                self.deactivate_devices_with_error_result(self.registration_id, e)
             raise
 
     def handle_topic_subscription(
@@ -677,6 +706,7 @@ class AbstractFCMDevice(Device):
         """
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         _r_ids = [self.registration_id]
+        from firebase_admin import messaging
         response = (
             messaging.subscribe_to_topic
             if should_subscribe
@@ -694,17 +724,21 @@ class AbstractFCMDevice(Device):
     def deactivate_devices_with_error_result(
         cls, registration_id, firebase_exc, name=None
     ) -> list[str]:
+        from firebase_admin import messaging
+
         return cls.objects.deactivate_devices_with_error_results(
             [registration_id], [messaging.SendResponse({"name": name}, firebase_exc)]
         )
 
     @staticmethod
     def send_topic_message(
-        message: messaging.Message,
+        message: "messaging.Message",
         topic_name: str,
         app: Optional["firebase_admin.App"] = None,
         **more_send_message_kwargs,
     ) -> messaging.SendResponse:
+        from firebase_admin import messaging
+
         app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
         message.topic = topic_name
 

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -25,6 +25,48 @@ MAX_DEVICES_PER_SUBSCRIBE_REQUEST = 1000
 
 # firebase_admin imports moved to where they're used to avoid eager loading
 
+_cached_app = None
+
+
+def _get_app(app=None):
+    """Get Firebase app, initializing lazily if INITIALIZE_APP_CALLABLE is set."""
+    global _cached_app
+
+    if app is not None:
+        return app
+
+    if _cached_app is not None:
+        return _cached_app
+
+    if SETTINGS.get("DEFAULT_FIREBASE_APP") is not None:
+        _cached_app = SETTINGS["DEFAULT_FIREBASE_APP"]
+        return _cached_app
+
+    from firebase_admin import get_app
+
+    try:
+        _cached_app = get_app()
+        return _cached_app
+    except ValueError:
+        pass
+
+    init_callable = SETTINGS.get("INITIALIZE_APP_CALLABLE")
+    if not init_callable:
+        return None
+
+    result = init_callable()
+    if result is not None:
+        _cached_app = result
+        return _cached_app
+
+    try:
+        _cached_app = get_app()
+        return _cached_app
+    except ValueError:
+        raise ValueError(
+            "INITIALIZE_APP_CALLABLE must return an App or call initialize_app()"
+        )
+
 
 class Device(models.Model):
     id = models.AutoField(
@@ -242,6 +284,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
+        app = _get_app(app)
         registration_ids = self.get_registration_ids(
             skip_registration_id_lookup,
             additional_registration_ids,
@@ -588,6 +631,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
+        app = _get_app(app)
         registration_ids = self.get_registration_ids(
             skip_registration_id_lookup,
             additional_registration_ids,
@@ -669,6 +713,8 @@ class AbstractFCMDevice(Device):
         """
         from firebase_admin import messaging
 
+        app = _get_app(app)
+
         if not self.active:
             return messaging.SendResponse(
                 None,
@@ -710,9 +756,10 @@ class AbstractFCMDevice(Device):
         :raises FirebaseError
         :returns FirebaseResponseDict
         """
-        app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
-        _r_ids = [self.registration_id]
         from firebase_admin import messaging
+
+        app = _get_app(app)
+        _r_ids = [self.registration_id]
 
         response = (
             messaging.subscribe_to_topic
@@ -746,7 +793,7 @@ class AbstractFCMDevice(Device):
     ) -> messaging.SendResponse:
         from firebase_admin import messaging
 
-        app = SETTINGS["DEFAULT_FIREBASE_APP"] if app is None else app
+        app = _get_app(app)
         message.topic = topic_name
 
         return messaging.SendResponse(

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -84,7 +84,7 @@ def _get_fcm_error_list_str():
     return [x.code for x in _get_fcm_error_list()]
 
 
-def _validate_exception_for_deactivation(exc: Union[FirebaseError]) -> bool:
+def _validate_exception_for_deactivation(exc: FirebaseError) -> bool:
     InvalidArgumentError = invalid_argument_error_type()
 
     if not exc:
@@ -123,7 +123,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def _render_message_template(
-        template: str, template_data: Optional[dict[str, Any]] = None
+        template: str, template_data: dict[str, Any] | None = None
     ) -> str:
         if not template_data:
             return template
@@ -312,11 +312,11 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         self,
         title_template: str,
         body_template: str,
-        message_data: Optional[dict[str, dict[str, Any]]] = None,
-        data_fields: Optional[dict[str, Any]] = None,
+        message_data: dict[str, dict[str, Any]] | None = None,
+        data_fields: dict[str, Any] | None = None,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional[firebase_admin.App] = None,
+        app: firebase_admin.App | None = None,
         **more_send_message_kwargs,
     ) -> FirebaseResponseDict:
         """
@@ -414,7 +414,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         *,
         reason: str,
         source: str,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> list[str]:
         active_devices = self.filter(active=True)
         device_rows = [
@@ -462,7 +462,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     def deactivate_devices_with_error_results(
         self,
         registration_ids: list[str],
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[messaging.SendResponse | messaging.ErrorInfo],
     ) -> list[str]:
         deactivation_candidates = self._get_deactivation_candidates(
             registration_ids, results
@@ -511,7 +511,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def _get_failed_exception_codes(
-        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
+        results: list[messaging.SendResponse | messaging.ErrorInfo],
     ) -> list[str]:
         messaging = firebase_messaging()
 
@@ -534,7 +534,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         device_rows: list[DeviceDeactivationData],
         reason: str,
         source: str,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         if not device_rows or not SETTINGS["EMIT_DEVICE_DEACTIVATED_SIGNAL"]:
             return
@@ -643,7 +643,7 @@ class AbstractFCMDevice(Device):
         unique=not SETTINGS["MYSQL_COMPATIBILITY"],
     )
     type = models.CharField(choices=DeviceType.choices, max_length=10)
-    objects: "FCMDeviceQuerySet" = FCMDeviceManager()
+    objects: FCMDeviceQuerySet = FCMDeviceManager()
 
     class Meta:
         abstract = True

--- a/fcm_django/models.py
+++ b/fcm_django/models.py
@@ -84,7 +84,7 @@ def _get_fcm_error_list_str():
     return [x.code for x in _get_fcm_error_list()]
 
 
-def _validate_exception_for_deactivation(exc: Union["FirebaseError"]) -> bool:
+def _validate_exception_for_deactivation(exc: Union[FirebaseError]) -> bool:
     InvalidArgumentError = invalid_argument_error_type()
 
     if not exc:
@@ -107,7 +107,7 @@ class _MissingFormatDict(dict[str, Any]):
 
 class FCMDeviceQuerySet(models.query.QuerySet):
     @staticmethod
-    def _prepare_message(message: "messaging.Message", token: str):
+    def _prepare_message(message: messaging.Message, token: str):
         message.token = token
         return copy(message)
 
@@ -219,10 +219,10 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     def send_message(
         self,
-        message: "messaging.Message",
+        message: messaging.Message,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App = None,
         **more_send_message_kwargs,
     ) -> FirebaseResponseDict:
         """
@@ -316,7 +316,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         data_fields: Optional[dict[str, Any]] = None,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional["firebase_admin.App"] = None,
+        app: Optional[firebase_admin.App] = None,
         **more_send_message_kwargs,
     ) -> FirebaseResponseDict:
         """
@@ -462,7 +462,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
     def deactivate_devices_with_error_results(
         self,
         registration_ids: list[str],
-        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
+        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
     ) -> list[str]:
         deactivation_candidates = self._get_deactivation_candidates(
             registration_ids, results
@@ -511,7 +511,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
 
     @staticmethod
     def _get_failed_exception_codes(
-        results: list[Union["messaging.SendResponse", "messaging.ErrorInfo"]],
+        results: list[Union[messaging.SendResponse, messaging.ErrorInfo]],
     ) -> list[str]:
         messaging = firebase_messaging()
 
@@ -569,7 +569,7 @@ class FCMDeviceQuerySet(models.query.QuerySet):
         topic: str,
         skip_registration_id_lookup: bool = False,
         additional_registration_ids: Sequence[str] = None,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App = None,
         **more_subscribe_kwargs,
     ) -> FirebaseResponseDict:
         """
@@ -654,10 +654,10 @@ class AbstractFCMDevice(Device):
 
     def send_message(
         self,
-        message: "messaging.Message",
-        app: Optional["firebase_admin.App"] = None,
+        message: messaging.Message,
+        app: firebase_admin.App = None,
         **more_send_message_kwargs,
-    ) -> "messaging.SendResponse":
+    ) -> messaging.SendResponse:
         """
         Send single message. The message's token should be blank (and will be
         overridden if not). Responds with message ID string.
@@ -697,7 +697,7 @@ class AbstractFCMDevice(Device):
         self,
         should_subscribe: bool,
         topic: str,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App = None,
         **more_subscribe_kwargs,
     ) -> FirebaseResponseDict:
         """
@@ -744,11 +744,11 @@ class AbstractFCMDevice(Device):
 
     @staticmethod
     def send_topic_message(
-        message: "messaging.Message",
+        message: messaging.Message,
         topic_name: str,
-        app: Optional["firebase_admin.App"] = None,
+        app: firebase_admin.App = None,
         **more_send_message_kwargs,
-    ) -> "messaging.SendResponse":
+    ) -> messaging.SendResponse:
         messaging = firebase_messaging()
         app = get_app(app)
         message.topic = topic_name

--- a/fcm_django/settings.py
+++ b/fcm_django/settings.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 DEFAULT_SETTINGS = {
     "DEFAULT_FIREBASE_APP": None,
-    "INITIALIZE_APP_CALLABLE": None,
+    "FIREBASE_APP_INITIALIZER": None,
     "APP_VERBOSE_NAME": _("FCM Django"),
     "ONE_DEVICE_PER_USER": False,
     "DELETE_INACTIVE_DEVICES": False,

--- a/fcm_django/settings.py
+++ b/fcm_django/settings.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 DEFAULT_SETTINGS = {
     "DEFAULT_FIREBASE_APP": None,
+    "INITIALIZE_APP_CALLABLE": None,
     "APP_VERBOSE_NAME": _("FCM Django"),
     "ONE_DEVICE_PER_USER": False,
     "DELETE_INACTIVE_DEVICES": False,

--- a/fcm_django/types.py
+++ b/fcm_django/types.py
@@ -1,7 +1,10 @@
-from typing import Any, NamedTuple
+from __future__ import annotations
 
-from firebase_admin import messaging
-from firebase_admin.exceptions import FirebaseError
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from firebase_admin import messaging
+    from firebase_admin.exceptions import FirebaseError
 
 
 class FirebaseResponseDict(NamedTuple):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ from fcm_django.models import DeviceType
 
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
 
-# firebase_admin imports moved to where they're used to avoid eager loading
-
 
 @pytest.fixture
 def username() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from fcm_django.models import DeviceType
 
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
 
+# firebase_admin imports moved to where they're used to avoid eager loading
+
 
 @pytest.fixture
 def username() -> str:
@@ -45,12 +47,14 @@ def fcm_device(registration_id: str):
 @pytest.fixture
 def message() -> "Message":
     from firebase_admin.messaging import Message
+
     return Message(data={"foo": "bar"})
 
 
 @pytest.fixture
 def firebase_error() -> "FirebaseError":
     from firebase_admin.exceptions import FirebaseError
+
     return FirebaseError(code=500, message="message")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, sentinel
 
 import pytest
 import swapper
-from firebase_admin.exceptions import FirebaseError
-from firebase_admin.messaging import Message
 from pytest_mock import MockerFixture
+
+if TYPE_CHECKING:
+    from firebase_admin.messaging import Message
+    from firebase_admin.exceptions import FirebaseError
 
 from fcm_django.models import DeviceType
 
@@ -40,12 +43,14 @@ def fcm_device(registration_id: str):
 
 
 @pytest.fixture
-def message() -> Message:
+def message() -> "Message":
+    from firebase_admin.messaging import Message
     return Message(data={"foo": "bar"})
 
 
 @pytest.fixture
-def firebase_error() -> FirebaseError:
+def firebase_error() -> "FirebaseError":
+    from firebase_admin.exceptions import FirebaseError
     return FirebaseError(code=500, message="message")
 
 
@@ -59,14 +64,14 @@ def firebase_message_id_send():
 
 @pytest.fixture(autouse=True)
 def mock_firebase_send(mocker: MockerFixture, firebase_message_id_send):
-    mock = mocker.patch("fcm_django.models.messaging.send")
+    mock = mocker.patch("firebase_admin.messaging.send")
     mock.return_value = firebase_message_id_send
     return mock
 
 
 @pytest.fixture
 def mock_firebase_send_each(mocker: MockerFixture):
-    mock = mocker.patch("fcm_django.models.messaging.send_each")
+    mock = mocker.patch("firebase_admin.messaging.send_each")
     mock.return_value = sentinel.FIREBASE_SEND_EACH_RESPONSE
     mock.return_value.responses = []
     return mock
@@ -75,7 +80,7 @@ def mock_firebase_send_each(mocker: MockerFixture):
 @pytest.fixture
 def mock_firebase_send_each_async(mocker: MockerFixture):
     mock = mocker.patch(
-        "fcm_django.models.messaging.send_each_async", new_callable=AsyncMock
+        "firebase_admin.messaging.send_each_async", new_callable=AsyncMock
     )
     mock.return_value = sentinel.FIREBASE_SEND_EACH_ASYNC_RESPONSE
     mock.return_value.responses = []

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -37,7 +37,7 @@ def test_send_message_action_handles_firebase_error(
     client, base_admin_url, fcm_device, mocker
 ):
     mocker.patch(
-        "fcm_django.models.messaging.send",
+        "firebase_admin.messaging.send",
         side_effect=FirebaseError(code="unknown", message="firebase failed"),
     )
 
@@ -60,7 +60,7 @@ def test_send_topic_message_action_handles_firebase_error(
     client, base_admin_url, fcm_device, mocker
 ):
     mocker.patch(
-        "fcm_django.models.messaging.send",
+        "firebase_admin.messaging.send",
         side_effect=FirebaseError(code="unknown", message="firebase failed"),
     )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,6 @@ from fcm_django.models import DeviceType
 from fcm_django.signals import device_deactivated
 from fcm_django.types import FirebaseResponseDict
 
-
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,8 +23,6 @@ from fcm_django.models import DeviceType
 from fcm_django.signals import device_deactivated
 from fcm_django.types import FirebaseResponseDict
 
-# firebase_admin imports moved to where they're used to avoid eager loading
-
 
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,11 +110,11 @@ class TestFCMDeviceSendMessage:
         self,
         result: Any,
         fcm_device: FCMDevice,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
         message_id: str,
         app: Any = None,
-        send_message_kwargs: Optional[dict] = None,
+        send_message_kwargs: dict | None = None,
     ):
         send_message_kwargs = send_message_kwargs or {}
 
@@ -135,7 +135,7 @@ class TestFCMDeviceSendMessage:
     def test_ok(
         self,
         fcm_device: FCMDevice,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -151,7 +151,7 @@ class TestFCMDeviceSendMessage:
     def test_custom_params(
         self,
         fcm_device: FCMDevice,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -200,9 +200,9 @@ class TestFCMDeviceSendMessage:
     def test_firebase_error(
         self,
         fcm_device: FCMDevice,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
-        firebase_error: "FirebaseError",
+        firebase_error: FirebaseError,
     ):
         """
         Ensure when happened unknown firebase error device is still active and raised the FirebaseError
@@ -221,7 +221,7 @@ class TestFCMDeviceSendMessage:
     def test_firebase_invalid_registration_error(
         self,
         fcm_device: FCMDevice,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
     ):
         """
@@ -265,12 +265,12 @@ class TestFCMDeviceSendTopicMessage:
     def assert_sent_successfully(
         self,
         result: Any,
-        message: "Message",
+        message: Message,
         topic: str,
         mock_firebase_send: MagicMock,
         message_id: str,
         app: Any = None,
-        send_message_kwargs: Optional[dict] = None,
+        send_message_kwargs: dict | None = None,
     ):
         send_message_kwargs = send_message_kwargs or {}
 
@@ -289,7 +289,7 @@ class TestFCMDeviceSendTopicMessage:
 
     def test_ok(
         self,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -306,7 +306,7 @@ class TestFCMDeviceSendTopicMessage:
 
     def test_custom_params(
         self,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -334,9 +334,9 @@ class TestFCMDeviceSendTopicMessage:
 
     def test_firebase_error(
         self,
-        message: "Message",
+        message: Message,
         mock_firebase_send: MagicMock,
-        firebase_error: "FirebaseError",
+        firebase_error: FirebaseError,
     ):
         """
         Ensure we raise an error in case firebase_admin.messaging.send throws one

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import MagicMock, sentinel
 from uuid import UUID
 
 import pytest
+
+if TYPE_CHECKING:
+    from firebase_admin.messaging import Message
+    from firebase_admin.exceptions import FirebaseError
 import swapper
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -103,7 +109,7 @@ class TestFCMDeviceSendMessage:
         self,
         result: Any,
         fcm_device: FCMDevice,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
         message_id: str,
         app: Any = None,
@@ -120,13 +126,14 @@ class TestFCMDeviceSendMessage:
 
         # Ensure we properly construct the response with the exact same message that was
         # obtained from messaging.send call
+        from firebase_admin.messaging import SendResponse
         assert isinstance(result, SendResponse)
         assert result.message_id == message_id
 
     def test_ok(
         self,
         fcm_device: FCMDevice,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -142,7 +149,7 @@ class TestFCMDeviceSendMessage:
     def test_custom_params(
         self,
         fcm_device: FCMDevice,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -191,15 +198,16 @@ class TestFCMDeviceSendMessage:
     def test_firebase_error(
         self,
         fcm_device: FCMDevice,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
-        firebase_error: FirebaseError,
+        firebase_error: "FirebaseError",
     ):
         """
         Ensure when happened unknown firebase error device is still active and raised the FirebaseError
         """
         mock_firebase_send.side_effect = firebase_error
 
+        from firebase_admin.exceptions import FirebaseError
         with pytest.raises(FirebaseError, match=str(firebase_error)):
             fcm_device.send_message(message)
 
@@ -210,12 +218,13 @@ class TestFCMDeviceSendMessage:
     def test_firebase_invalid_registration_error(
         self,
         fcm_device: FCMDevice,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
     ):
         """
         Ensure when Invalid registration firebase error device is still active and raised the FirebaseError
         """
+        from firebase_admin.exceptions import FirebaseError, InvalidArgumentError
         firebase_invalid_registration_error = InvalidArgumentError(
             message="Error", cause="Invalid registration"
         )
@@ -252,7 +261,7 @@ class TestFCMDeviceSendTopicMessage:
     def assert_sent_successfully(
         self,
         result: Any,
-        message: Message,
+        message: "Message",
         topic: str,
         mock_firebase_send: MagicMock,
         message_id: str,
@@ -269,12 +278,13 @@ class TestFCMDeviceSendTopicMessage:
 
         # Ensure we properly construct the response with the exact same message that was
         # obtained from messaging.send call
+        from firebase_admin.messaging import SendResponse
         assert isinstance(result, SendResponse)
         assert result.message_id == message_id
 
     def test_ok(
         self,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -291,7 +301,7 @@ class TestFCMDeviceSendTopicMessage:
 
     def test_custom_params(
         self,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
         firebase_message_id_send: str,
     ):
@@ -319,15 +329,16 @@ class TestFCMDeviceSendTopicMessage:
 
     def test_firebase_error(
         self,
-        message: Message,
+        message: "Message",
         mock_firebase_send: MagicMock,
-        firebase_error: FirebaseError,
+        firebase_error: "FirebaseError",
     ):
         """
         Ensure we raise an error in case firebase_admin.messaging.send throws one
         """
         mock_firebase_send.side_effect = firebase_error
 
+        from firebase_admin.exceptions import FirebaseError
         with pytest.raises(FirebaseError, match=str(firebase_error)):
             FCMDevice.send_topic_message(message, "example")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ import pytest
 if TYPE_CHECKING:
     from firebase_admin.messaging import Message
     from firebase_admin.exceptions import FirebaseError
+
 import swapper
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -21,6 +22,9 @@ from firebase_admin.messaging import Message, SendResponse
 from fcm_django.models import DeviceType
 from fcm_django.signals import device_deactivated
 from fcm_django.types import FirebaseResponseDict
+
+# firebase_admin imports moved to where they're used to avoid eager loading
+
 
 FCMDevice = swapper.load_model("fcm_django", "fcmdevice")
 
@@ -127,6 +131,7 @@ class TestFCMDeviceSendMessage:
         # Ensure we properly construct the response with the exact same message that was
         # obtained from messaging.send call
         from firebase_admin.messaging import SendResponse
+
         assert isinstance(result, SendResponse)
         assert result.message_id == message_id
 
@@ -208,6 +213,7 @@ class TestFCMDeviceSendMessage:
         mock_firebase_send.side_effect = firebase_error
 
         from firebase_admin.exceptions import FirebaseError
+
         with pytest.raises(FirebaseError, match=str(firebase_error)):
             fcm_device.send_message(message)
 
@@ -225,6 +231,7 @@ class TestFCMDeviceSendMessage:
         Ensure when Invalid registration firebase error device is still active and raised the FirebaseError
         """
         from firebase_admin.exceptions import FirebaseError, InvalidArgumentError
+
         firebase_invalid_registration_error = InvalidArgumentError(
             message="Error", cause="Invalid registration"
         )
@@ -279,6 +286,7 @@ class TestFCMDeviceSendTopicMessage:
         # Ensure we properly construct the response with the exact same message that was
         # obtained from messaging.send call
         from firebase_admin.messaging import SendResponse
+
         assert isinstance(result, SendResponse)
         assert result.message_id == message_id
 
@@ -339,6 +347,7 @@ class TestFCMDeviceSendTopicMessage:
         mock_firebase_send.side_effect = firebase_error
 
         from firebase_admin.exceptions import FirebaseError
+
         with pytest.raises(FirebaseError, match=str(firebase_error)):
             FCMDevice.send_topic_message(message, "example")
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,6 @@
 import importlib
+import os
+import subprocess
 
 from django.test import override_settings
 from django.utils.functional import Promise
@@ -48,3 +50,25 @@ def test_runtime_settings_do_not_share_nested_defaults():
         errors["temporary"] = "TemporaryError"
 
     assert "temporary" not in DEFAULT_SETTINGS["ERRORS"]
+
+def test_importing_models_and_admin_does_not_eager_load_firebase_admin():
+    env = {
+        **os.environ,
+        "DJANGO_SETTINGS_MODULE": "tests.settings.default",
+    }
+    script = """
+import sys
+import django
+
+sys.modules.pop("firebase_admin", None)
+sys.modules.pop("firebase_admin.messaging", None)
+
+django.setup()
+
+import fcm_django.models
+import fcm_django.admin
+
+assert "firebase_admin" not in sys.modules
+assert "firebase_admin.messaging" not in sys.modules
+"""
+    subprocess.run(["python", "-c", script], env=env, check=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -51,6 +51,7 @@ def test_runtime_settings_do_not_share_nested_defaults():
 
     assert "temporary" not in DEFAULT_SETTINGS["ERRORS"]
 
+
 def test_importing_models_and_admin_does_not_eager_load_firebase_admin():
     env = {
         **os.environ,


### PR DESCRIPTION
## Changes
Lazily import `firebase_admin` and its modules because we've found it's one of the slower modules to import in our Django projects. For type annotations, the `firebase_admin` is only imported after checking `typing.TYPE_CHECKING`.

Please let me know if you have any suggestions or feedback on this, I'd be happy to implement them.

Thanks for this package, I think it's great!

## Tests
```bash
Test session starts (platform: linux, Python 3.10.12, pytest 8.2.2, pytest-sugar 1.0.0)
django: version: 4.2.19, settings: tests.settings.default (from ini)
rootdir: /home/nathanjones/Projects/fcm-django
configfile: pyproject.toml
plugins: sugar-1.0.0, anyio-3.6.2, mock-3.14.1, django-4.11.1, asyncio-0.14.0, Faker-15.3.4, typeguard-2.13.3
collected 16 items

 tests/test_admin.py ✓✓                                                                                                                                                                                                                      12% █▍
 tests/test_api_rest_framework.py ✓✓✓                                                                                                                                                                                                        31% ███▎
 tests/test_api_tastypie.py ✓                                                                                                                                                                                                                38% ███▊
 tests/test_models.py ✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                            100% ██████████

Results (3.49s):
      16 passed

```