### PR TITLE
Clean supported django versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2
+Django>=4.2
 django-tastypie>=0.14.0
 djangorestframework>=3.9.2
 firebase-admin>=6.2,<8

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Networking",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "fcm_django/migrations",
     ],
     python_requires=">=3.9",
-    install_requires=["firebase-admin>=6.2,<8", "Django", "swapper"],
+    install_requires=["firebase-admin>=6.2,<8", "Django>=4.2", "swapper"],
     author=fcm_django.__author__,
     author_email=fcm_django.__email__,
     classifiers=CLASSIFIERS,

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 min_version = 4
 envlist =
     {py39,py310,py311}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
+    {py310,py311,py312,py313}-{django51,django52}-{swap,noswap}-{sqlite,postgres,mariadb}-linux
 
 [gh-actions]
 python =
@@ -20,6 +21,8 @@ deps =
     -rrequirements.txt
     -rrequirements_test.txt
     django42: Django>=4.2,<4.3
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     postgres: psycopg2-binary>=2.9.6
     mariadb: mysqlclient>=2.1.1
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4
 envlist =
-    {py39,py310,py311}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
+    {py39,py310,py311,py312}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
     {py310,py311,py312,py313}-{django51,django52}-{swap,noswap}-{sqlite,postgres,mariadb}-linux
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 min_version = 4
 envlist =
-    {py39,py310}-django32-{swap,noswap}-{sqlite,postgres,mariadb}-linux
     {py39,py310,py311}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
 
 [gh-actions]
@@ -20,7 +19,6 @@ PLATFORM =
 deps =
     -rrequirements.txt
     -rrequirements_test.txt
-    django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     postgres: psycopg2-binary>=2.9.6
     mariadb: mysqlclient>=2.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 min_version = 4
-envlist = 
-    {py37,py38,py39,py310}-django32-{swap,noswap}-{sqlite,postgres,mariadb}-linux
-    {py38,py39,py310,py311}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
+envlist =
+    {py39,py310}-django32-{swap,noswap}-{sqlite,postgres,mariadb}-linux
+    {py39,py310,py311}-django42-{swap,noswap}-{sqlite,postgres,mariadb}-linux
 
 [gh-actions]
 python =


### PR DESCRIPTION
* Removes anything older than 4.2
* Adds support for 5.1 and 5.2

Depends on:
- https://github.com/xtrinch/fcm-django/pull/284